### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name"          : "Odoo::Client",
+    "license"       : "MIT",
     "version"       : "0.0.2",
     "perl"          : "6.c",
     "description"   : "A simple Odoo ERP client that uses JSON RPC",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license